### PR TITLE
feat(api): restructure MPESA endpoints with consistent prefix

### DIFF
--- a/backend/taxbackend/tax_api/mpesa/urls.py
+++ b/backend/taxbackend/tax_api/mpesa/urls.py
@@ -1,11 +1,22 @@
 from django.urls import path
-from .views import InitiateSTKPushView, MpesaCallbackView,DownloadReceiptView,TransactionHistoryView,PaymentTransactionDetailView
+from .views import (
+    InitiateSTKPushView,
+    MpesaCallbackView,
+    DownloadReceiptView,
+    TransactionHistoryView,
+    PaymentTransactionDetailView
+)
 
 urlpatterns = [
+    # Keep existing STK push endpoints
     path('initiate-stk-push/', InitiateSTKPushView.as_view(), name='initiate-stk-push'),
     path('callback/', MpesaCallbackView.as_view(), name='mpesa-callback'),
-    path('receipt/<int:transaction_id>/', DownloadReceiptView.as_view(), name='download-receipt'),
-    path('payment-transactions/<int:transaction_id>/', PaymentTransactionDetailView.as_view(), name='transaction-detail'),
-    path('transactions/history/', TransactionHistoryView.as_view(), name='transaction-history'),
+    
+    # Update receipt endpoint to match frontend
+    path('receipt/<str:transaction_id>/', DownloadReceiptView.as_view(), name='download-receipt'),
+    
+    # Transaction endpoints (now under /api/mpesa/ prefix)
+    path('api/mpesa/transactions/history/', TransactionHistoryView.as_view(), name='transaction-history'),
+    path('api/mpesa/payment-transactions/<str:transaction_id>/', 
+         PaymentTransactionDetailView.as_view(), name='transaction-detail'),
 ]
-

--- a/backend/taxbackend/tax_api/mpesa/views.py
+++ b/backend/taxbackend/tax_api/mpesa/views.py
@@ -71,27 +71,21 @@ class TransactionHistoryView(APIView):
                 user=request.user
             ).order_by('-created_at')
             
-            if not transactions.exists():
-                return Response(
-                    {"message": "No transactions found"},
-                    status=status.HTTP_200_OK
-                )
-                
             serializer = PaymentTransactionSerializer(transactions, many=True)
+            
             return Response({
                 "success": True,
+                "message": "Transactions retrieved successfully",
                 "data": serializer.data
             })
             
         except Exception as e:
-            return Response(
-                {
-                    "success": False,
-                    "message": str(e)
-                },
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
-        
+            logger.error(f"Transaction History Error - User {request.user.id}: {str(e)}")
+            return Response({
+                "success": False,
+                "message": "Failed to retrieve transactions",
+                "error": str(e)
+            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)     
 @method_decorator(csrf_exempt, name='dispatch')
 class DownloadReceiptView(APIView):
     permission_classes = [IsAuthenticated]

--- a/frontend/tax-collection-ui/src/pages/VendorDashboard.jsx
+++ b/frontend/tax-collection-ui/src/pages/VendorDashboard.jsx
@@ -126,22 +126,22 @@ const VendorDashboard = () => {
     setShowModal(true);
   };
 
-  const fetchTransactions = async () => {
+ const fetchTransactions = async () => {
   try {
     setLoading(true);
     setError(null);
-    const response = await getPaymentTransactions();
     
-    if (response?.success) {
+    const response = await getPaymentTransactions();
+    console.log('Transactions Response:', response); // Debug
+    
+    if (response.success) {
       setTransactions(response.data || []);
     } else {
-      setError(response?.message || "No transactions data received");
-      setTransactions([]);
+      setError(response.message);
     }
   } catch (err) {
-    console.error("Fetch error:", err);
-    setError(err.message);
-    setTransactions([]);
+    console.error("Unexpected error:", err);
+    setError("An unexpected error occurred");
   } finally {
     setLoading(false);
   }

--- a/frontend/tax-collection-ui/src/services/mpesaService.js
+++ b/frontend/tax-collection-ui/src/services/mpesaService.js
@@ -39,14 +39,20 @@ export const downloadReceipt = async (transactionId) => {
 
 export const getPaymentTransactions = async () => {
   try {
-    const response = await api.get('/api/transactions/history/'); // Changed endpoint
-    return response.data;
+    const response = await api.get('/api/mpesa/transactions/history/'); 
+    return {
+      success: true,
+      data: response.data.data || response.data // Handle both response formats
+    };
   } catch (error) {
-    console.error('Error details:', {
+    console.error('Transaction History Error:', {
       status: error.response?.status,
       data: error.response?.data,
       config: error.config
     });
-    throw new Error(error.response?.data?.message || 'Failed to fetch transactions. Please try again.');
+    return {  // Return object instead of throwing
+      success: false,
+      message: error.response?.data?.message || 'Failed to fetch transactions'
+    };
   }
 };


### PR DESCRIPTION
- Add '/api/mpesa/' prefix to all transaction endpoints
- Change transaction_id param from int to str to support UUIDs
- Maintain backward compatibility for callback URLs
- Update frontend service to match new endpoints